### PR TITLE
Update Paths.java

### DIFF
--- a/src/main/java/org/jahia/modules/jcrestapi/Paths.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/Paths.java
@@ -149,7 +149,7 @@ public class Paths extends API {
     @DELETE
     @Path("/{path: .*}")
     public Object delete(@Context UriInfo context) {
-        return performByPath(context, CREATE_OR_UPDATE, null);
+        return performByPath(context, DELETE, null);
     }
 
 


### PR DESCRIPTION
Operating on nodes using their path : 
When a DELETE request is submitted, we get an error 400 with the message "Missing Body".
This is caused by the fact that the performByPath is called but with the wrong 'operation' parameter (the constant CREATE_OR_UPDATE instead of the constant DELETE).