### PR TITLE
feat: configurable deprecation warning

### DIFF
--- a/src/main/java/org/jahia/modules/jcrestapi/APIApplication.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/APIApplication.java
@@ -68,6 +68,7 @@ public class APIApplication extends ResourceConfig {
                 bindFactory(repositoryFactoryClass).to(Repository.class);
             }
         });
+        register(JCRRestAPIDeprecationFilter.class);
         property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
         property(ServerProperties.WADL_FEATURE_DISABLE, true);
 

--- a/src/main/java/org/jahia/modules/jcrestapi/JCRRestAPIDeprecationFilter.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/JCRRestAPIDeprecationFilter.java
@@ -1,0 +1,67 @@
+package org.jahia.modules.jcrestapi;
+
+import org.jahia.osgi.BundleUtils;
+import org.jahia.settings.SettingsBean;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A filter that logs deprecation warnings for deprecated REST API endpoints.
+ */
+@Provider
+public class JCRRestAPIDeprecationFilter implements ContainerRequestFilter {
+
+    public static final Logger logger = LoggerFactory.getLogger(JCRRestAPIDeprecationFilter.class);
+    private static final Map<String, Long> loggedPaths = new ConcurrentHashMap<>();
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
+        long logAgainThreshold = TimeUnit.HOURS.toMillis(24); // default re-log every 24 hours
+
+        if (configAdmin != null) {
+            Configuration configuration = configAdmin.getConfiguration("org.jahia.modules.jcrestapi");
+            if (configuration.getProperties() != null) {
+                if (Boolean.parseBoolean((String) configuration.getProperties().get("deprecation.warning.disabled"))) {
+                    // deprecation warning is disabled
+                    return;
+                }
+
+                String logAgainThresholdStr = (String) configuration.getProperties().get("deprecation.warning.logAgainThreshold.hour");
+                if (logAgainThresholdStr != null) {
+                    try {
+                        logAgainThreshold = TimeUnit.HOURS.toMillis(Long.parseLong(logAgainThresholdStr));
+                    } catch (NumberFormatException e) {
+                        logger.error("Invalid number format for deprecation.warning.logAgainThreshold.hour, fallback to 24", e);
+                    }
+                }
+            }
+        }
+
+        UriInfo uriInfo = requestContext.getUriInfo();
+        String method = requestContext.getMethod();
+        String basePath = uriInfo.getBaseUri().getPath();
+        String apiPath = uriInfo.getPath();
+        String key = method + " " + apiPath;
+        long now = Instant.now().toEpochMilli();
+
+        Long lastLogged = loggedPaths.get(key);
+        if (lastLogged == null || now - lastLogged >= logAgainThreshold) {
+            logger.warn("JCR REST API is deprecated. Received a {} request to endpoint: [{}]. " +
+                    "Please refer to the GraphQL API for supported alternatives.", method, basePath + apiPath);
+            loggedPaths.put(key, now);
+        }
+    }
+}

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jcrestapi.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jcrestapi.cfg
@@ -1,0 +1,8 @@
+# default configuration - won't be overridden
+
+# JCR REST API is deprecated in favor of GraphQL API
+# Warning messages are logged by default to inform users about the deprecation
+# Set this property to true to disable the warning messages
+deprecation.warning.disabled = false
+# The duration in hours after which the warning message will be logged again for a given endpoint
+deprecation.warning.logAgainThreshold.hour = 24


### PR DESCRIPTION
New deprecation warning is implemented on the JCR REST API in order to encourage migration to GraphQL supported API.

new configuration file: org.jahia.modules.jcrestapi.cfg

with properties:
- deprecation.warning.disabled -> allows to disable the warning message totally, for peoples that still want to use the JCR REST API without deprecation warning logs
- deprecation.warning.logAgainThreshold.hour -> allows to control the number of hours between a warning being logged again for a given endpoint.

The implem will remind which endpoints have been logged as warning already to avoid flooding the console/log files. By default a single API access with use the path of the endpoint and the method.
For example if you access this URL: http://localhost:8080/modules/api/jcr/v1/version

You will see a log: 
`2025-02-28 15:57:15,675: WARN  [JCRRestAPIDeprecationFilter] - JCR REST API is deprecated. Received a GET request to endpoint: [/modules/api/jcr/v1/version]. Please refer to the GraphQL API for supported alternatives.`

if you access again the same endpoint, in the configured threshold (default to 24h) you wont be notified again for this endpoint.

but if you access an other endpoint, like: http://localhost:8080/modules/api/jcr/v1/default/en/nodes/sites
you will be notified again:
`2025-02-28 16:00:17,917: WARN  [JCRRestAPIDeprecationFilter] - JCR REST API is deprecated. Received a GET request to endpoint: [/modules/api/jcr/v1/default/en/nodes/sites]. Please refer to the GraphQL API for supported alternatives.`