### PR TITLE
fix: Disable JCRRestAPIDeprecationFilter during tests

### DIFF
--- a/src/main/java/org/jahia/modules/jcrestapi/APIApplication.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/APIApplication.java
@@ -56,6 +56,11 @@ import javax.jcr.Repository;
  * @author Christophe Laprun
  */
 public class APIApplication extends ResourceConfig {
+    /**
+     * System property that can be used to disable the registration of {@link JCRRestAPIDeprecationFilter}.
+     */
+    public static final String SYS_PROP_DEPRECATION_FILTER_DISABLED = "jahia.JCRRestAPIDeprecationFilter.disabled";
+
     public APIApplication() {
         this(RepositoryFactory.class);
     }
@@ -68,7 +73,9 @@ public class APIApplication extends ResourceConfig {
                 bindFactory(repositoryFactoryClass).to(Repository.class);
             }
         });
-        register(JCRRestAPIDeprecationFilter.class);
+        if (!Boolean.getBoolean(SYS_PROP_DEPRECATION_FILTER_DISABLED)) {
+            register(JCRRestAPIDeprecationFilter.class);
+        }
         property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
         property(ServerProperties.WADL_FEATURE_DISABLE, true);
 

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -73,6 +73,7 @@ import static com.jayway.restassured.RestAssured.expect;
 import static com.jayway.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.*;
 import static org.hamcrest.Matchers.*;
+import static org.jahia.modules.jcrestapi.APIApplication.SYS_PROP_DEPRECATION_FILTER_DISABLED;
 
 /**
  * @author Christophe Laprun
@@ -104,6 +105,7 @@ public class APITest extends JerseyTest {
                 destroyRepository();
             }
         });
+        System.setProperty(SYS_PROP_DEPRECATION_FILTER_DISABLED, "true");
     }
 
     @AfterClass
@@ -117,6 +119,7 @@ public class APITest extends JerseyTest {
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
+        System.clearProperty(SYS_PROP_DEPRECATION_FILTER_DISABLED);
     }
 
     @Before


### PR DESCRIPTION
### Description
Addresses https://github.com/Jahia/jcrestapi/issues/58.

Disable the registration of `JCRRestAPIDeprecationFilter` during unit tests execution, as there is no OSGI context available and `BundleUtils.getOsgiService(ConfigurationAdmin.class, null)` fails.
This should fix the failures encountered in https://bamboo-qa-prod.int.jahia.com/bamboo/browse/JT71XX-JAHIATRUNKSONAR-3284/test.