### PR TITLE
fix: apply the node scope check to the node a deletion removes

### DIFF
--- a/.chachalog/GiADDPSt.md
+++ b/.chachalog/GiADDPSt.md
@@ -5,3 +5,5 @@ jcrestapi: patch
 Restricted batch deletions in the JCR REST API to the nodes it is configured to expose.
 
 A request that deletes several nodes at once now gets the same answer as a request that deletes them one at a time. A batch deletion that starts returning a not-found error after the upgrade targets a node outside that configuration. Grant the delete permission for the JCR REST API on that node, or remove the node's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`.
+
+Each name sent in the request body must also name a direct child of the node the request targets. A name that carries a path, such as `folder/child`, is refused. An integration that deleted a deeper node that way must send its request on the parent of that node instead.

--- a/.chachalog/GiADDPSt.md
+++ b/.chachalog/GiADDPSt.md
@@ -2,4 +2,6 @@
 jcrestapi: patch
 ---
 
-Restricted batch deletions in the JCR REST API to the nodes the API is configured to expose.
+Restricted batch deletions in the JCR REST API to the nodes it is configured to expose.
+
+A request that deletes several nodes at once now gets the same answer as a request that deletes them one at a time. A batch deletion that starts returning a not-found error after the upgrade targets a node outside that configuration. Grant the delete permission for the JCR REST API on that node, or remove the node's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`.

--- a/.chachalog/GiADDPSt.md
+++ b/.chachalog/GiADDPSt.md
@@ -5,5 +5,3 @@ jcrestapi: patch
 Restricted deletions in the JCR REST API to the nodes it is configured to expose.
 
 A deletion is now answered against the node it removes, and not only against the node the request path names. A request that removes a child is therefore refused when the API does not expose that child, whether the request removes one child or several at once. Grant the delete permission for the JCR REST API on that child, or remove the child's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`.
-
-A request that removes several nodes at once must name a direct child of the node it targets, once per name. A name that carries a path, such as `folder/child`, is refused. An integration that removed a deeper node that way must send its request on the parent of that node instead.

--- a/.chachalog/GiADDPSt.md
+++ b/.chachalog/GiADDPSt.md
@@ -1,0 +1,5 @@
+---
+jcrestapi: patch
+---
+
+Restricted batch deletions in the JCR REST API to the nodes the API is configured to expose.

--- a/.chachalog/GiADDPSt.md
+++ b/.chachalog/GiADDPSt.md
@@ -2,8 +2,8 @@
 jcrestapi: patch
 ---
 
-Restricted batch deletions in the JCR REST API to the nodes it is configured to expose.
+Restricted deletions in the JCR REST API to the nodes it is configured to expose.
 
-A request that deletes several nodes at once now gets the same answer as a request that deletes them one at a time. A batch deletion that starts returning a not-found error after the upgrade targets a node outside that configuration. Grant the delete permission for the JCR REST API on that node, or remove the node's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`.
+A deletion is now answered against the node it removes, and not only against the node the request path names. A request that removes a child is therefore refused when the API does not expose that child, whether the request removes one child or several at once. Grant the delete permission for the JCR REST API on that child, or remove the child's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`.
 
-Each name sent in the request body must also name a direct child of the node the request targets. A name that carries a path, such as `folder/child`, is refused. An integration that deleted a deeper node that way must send its request on the parent of that node instead.
+A request that removes several nodes at once must name a direct child of the node it targets, once per name. A name that carries a path, such as `folder/child`, is refused. An integration that removed a deeper node that way must send its request on the parent of that node instead.

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -394,6 +394,31 @@ public class API {
     }
 
     /**
+     * Checks the node a children deletion will remove, and not only the node the request resolved to.
+     *
+     * <p>{@code ChildrenElementAccessor.delete} removes {@code node.getNode(subElement)}, so the node that
+     * leaves the repository is the child. {@link #checkNodeIsInScope(Node, String)} on the resolved node says
+     * nothing about that child: one whose own primary type is excluded, or whose own path the caller's scope
+     * refuses, would still be removed. Both shapes of the delete route resolve their child here, so both
+     * answer for the node they remove.
+     *
+     * <p>A name that matches no child is left to the accessor, which reports it the same way as before.
+     *
+     * <p>Deletion only. Reading or writing a sub-element is a wider question than the node being removed,
+     * and a children listing already filters on {@code jcrestapi.child} through {@link #NODE_FILTER}.
+     *
+     * @param node       the node the request resolved to
+     * @param subElement the name of the child the request will remove
+     * @throws PathNotFoundException if the child is not exposed by the API
+     * @throws RepositoryException   if the child's primary type or path cannot be read
+     */
+    private void checkChildIsInScope(Node node, String subElement) throws RepositoryException {
+        if (subElement != null && !subElement.isEmpty() && node.hasNode(subElement)) {
+            checkNodeIsInScope(node.getNode(subElement), DELETE);
+        }
+    }
+
+    /**
      * Checks that the given sub-element is a plain name, and not a relative path.
      *
      * <p>The batch overload of {@link ElementAccessor#perform(Node, java.util.List, String, java.util.List,
@@ -465,8 +490,12 @@ public class API {
             final Node node = nodeAccessor.getNode(parentIdOrPath, session);
             checkNodeIsInScope(node, DELETE);
             if (subElements != null) {
+                final boolean children = JSONConstants.CHILDREN.equals(subElementType);
                 for (String subElement : subElements) {
                     checkIsPlainName(subElement);
+                    if (children) {
+                        checkChildIsInScope(node, subElement);
+                    }
                 }
             }
 
@@ -508,6 +537,9 @@ public class API {
 
             final Node node = nodeAccessor.getNode(idOrPath, session);
             checkNodeIsInScope(node, operation);
+            if (DELETE.equals(operation) && JSONConstants.CHILDREN.equals(subElementType)) {
+                checkChildIsInScope(node, subElement);
+            }
 
             final ElementAccessor accessor = ACCESSORS.get(subElementType);
             if (accessor != null) {

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -394,6 +394,22 @@ public class API {
     }
 
     /**
+     * Checks that the given node is exposed by the API for the given operation: its primary type must not be one of the
+     * excluded types, and the caller's scope must allow that operation on it.
+     *
+     * @param node      the node the request resolved to
+     * @param operation the operation about to be performed on that node
+     * @throws PathNotFoundException if the node is not exposed by the API
+     * @throws RepositoryException   if the node's primary type or path cannot be read
+     */
+    private void checkNodeIsInScope(Node node, String operation) throws RepositoryException {
+        if (excludedNodeTypes.contains(node.getPrimaryNodeType().getName())
+                || !SpringBeansAccess.getInstance().hasPermission("jcrestapi." + operation, node)) {
+            throw new PathNotFoundException(node.getPath());
+        }
+    }
+
+    /**
      * Performs a batch delete of all specified sub-element types identified by the given list of sub-elements. Note that this method could actually
      * be extended to include other types of batch operations.
      *
@@ -420,6 +436,7 @@ public class API {
             subElementType = processor.getSubElementType();
 
             final Node node = nodeAccessor.getNode(parentIdOrPath, session);
+            checkNodeIsInScope(node, DELETE);
 
             final ElementAccessor accessor = ACCESSORS.get(subElementType);
             if (accessor != null) {
@@ -458,9 +475,8 @@ public class API {
             session = getSession(workspace, language);
 
             final Node node = nodeAccessor.getNode(idOrPath, session);
-            if (excludedNodeTypes.contains(node.getPrimaryNodeType().getName()) || !SpringBeansAccess.getInstance().hasPermission("jcrestapi."+operation, node)) {
-                throw new PathNotFoundException(node.getPath());
-            }
+            checkNodeIsInScope(node, operation);
+
             final ElementAccessor accessor = ACCESSORS.get(subElementType);
             if (accessor != null) {
                 final Response response = accessor.perform(node, subElement, operation, data, context);

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -397,12 +397,14 @@ public class API {
      * Checks that the given node is exposed by the API for the given operation: its primary type must not be one of the
      * excluded types, and the caller's scope must allow that operation on it.
      *
+     * <p>Package-visible so that the subclasses answering a route apply the same rule as this class.
+     *
      * @param node      the node the request resolved to
      * @param operation the operation about to be performed on that node
      * @throws PathNotFoundException if the node is not exposed by the API
      * @throws RepositoryException   if the node's primary type or path cannot be read
      */
-    private void checkNodeIsInScope(Node node, String operation) throws RepositoryException {
+    void checkNodeIsInScope(Node node, String operation) throws RepositoryException {
         if (excludedNodeTypes.contains(node.getPrimaryNodeType().getName())
                 || !SpringBeansAccess.getInstance().hasPermission("jcrestapi." + operation, node)) {
             throw new PathNotFoundException(node.getPath());

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -394,6 +394,31 @@ public class API {
     }
 
     /**
+     * Checks that the given sub-element is a plain name, and not a relative path.
+     *
+     * <p>The batch overload of {@link ElementAccessor#perform(Node, java.util.List, String, java.util.List,
+     * UriInfo)} passes each name straight to {@link Node#getNode(String)}, which resolves a <em>relative
+     * path</em>: {@code a/b} and {@code ../sibling} are valid arguments there. A name carrying a path
+     * would therefore reach a node other than the one {@link #checkNodeIsInScope(Node, String)} approved.
+     * The single-element routes cannot express one, because a sub-element reaches them as a single URI
+     * segment.
+     *
+     * <p>The three refused shapes are the whole of JCR's relative-path syntax, so what remains is a name.
+     * Refusing shapes rather than allowing characters is deliberate: a JCR name accepts a namespace
+     * prefix ({@code jcr:content}), a space, and a same-name-sibling index ({@code child[2]}), so an
+     * allow-list would refuse names this API is expected to carry.
+     *
+     * @param subElement the name of a sub-element the request asks to operate on
+     * @throws PathNotFoundException if the sub-element is a path rather than a name
+     */
+    private static void checkIsPlainName(String subElement) throws PathNotFoundException {
+        if (subElement != null
+                && (subElement.indexOf('/') >= 0 || ".".equals(subElement) || "..".equals(subElement))) {
+            throw new PathNotFoundException(subElement);
+        }
+    }
+
+    /**
      * Checks that the given node is exposed by the API for the given operation: its primary type must not be one of the
      * excluded types, and the caller's scope must allow that operation on it.
      *
@@ -439,6 +464,11 @@ public class API {
 
             final Node node = nodeAccessor.getNode(parentIdOrPath, session);
             checkNodeIsInScope(node, DELETE);
+            if (subElements != null) {
+                for (String subElement : subElements) {
+                    checkIsPlainName(subElement);
+                }
+            }
 
             final ElementAccessor accessor = ACCESSORS.get(subElementType);
             if (accessor != null) {

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -402,6 +402,12 @@ public class API {
      * refuses, would still be removed. Both shapes of the delete route resolve their child here, so both
      * answer for the node they remove.
      *
+     * <p>The name resolves the way {@link Node#getNode(String)} resolves it, as a <em>relative path</em>
+     * rather than a name, so {@code ../sibling} names a node outside this one. That is deliberate: the
+     * check resolves through the same call the accessor removes through, so the node checked here is the
+     * node removed there whatever shape the name takes. Refusing the shape instead would refuse
+     * {@code folder/child}, which is how a caller removes a deeper node in one request.
+     *
      * <p>A name that matches no child is left to the accessor, which reports it the same way as before.
      *
      * <p>Deletion only. Reading or writing a sub-element is a wider question than the node being removed,
@@ -415,31 +421,6 @@ public class API {
     private void checkChildIsInScope(Node node, String subElement) throws RepositoryException {
         if (subElement != null && !subElement.isEmpty() && node.hasNode(subElement)) {
             checkNodeIsInScope(node.getNode(subElement), DELETE);
-        }
-    }
-
-    /**
-     * Checks that the given sub-element is a plain name, and not a relative path.
-     *
-     * <p>The batch overload of {@link ElementAccessor#perform(Node, java.util.List, String, java.util.List,
-     * UriInfo)} passes each name straight to {@link Node#getNode(String)}, which resolves a <em>relative
-     * path</em>: {@code a/b} and {@code ../sibling} are valid arguments there. A name carrying a path
-     * would therefore reach a node other than the one {@link #checkNodeIsInScope(Node, String)} approved.
-     * The single-element routes cannot express one, because a sub-element reaches them as a single URI
-     * segment.
-     *
-     * <p>The three refused shapes are the whole of JCR's relative-path syntax, so what remains is a name.
-     * Refusing shapes rather than allowing characters is deliberate: a JCR name accepts a namespace
-     * prefix ({@code jcr:content}), a space, and a same-name-sibling index ({@code child[2]}), so an
-     * allow-list would refuse names this API is expected to carry.
-     *
-     * @param subElement the name of a sub-element the request asks to operate on
-     * @throws PathNotFoundException if the sub-element is a path rather than a name
-     */
-    private static void checkIsPlainName(String subElement) throws PathNotFoundException {
-        if (subElement != null
-                && (subElement.indexOf('/') >= 0 || ".".equals(subElement) || "..".equals(subElement))) {
-            throw new PathNotFoundException(subElement);
         }
     }
 
@@ -489,13 +470,9 @@ public class API {
 
             final Node node = nodeAccessor.getNode(parentIdOrPath, session);
             checkNodeIsInScope(node, DELETE);
-            if (subElements != null) {
-                final boolean children = JSONConstants.CHILDREN.equals(subElementType);
+            if (subElements != null && JSONConstants.CHILDREN.equals(subElementType)) {
                 for (String subElement : subElements) {
-                    checkIsPlainName(subElement);
-                    if (children) {
-                        checkChildIsInScope(node, subElement);
-                    }
+                    checkChildIsInScope(node, subElement);
                 }
             }
 

--- a/src/main/java/org/jahia/modules/jcrestapi/Paths.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/Paths.java
@@ -210,9 +210,7 @@ public class Paths extends API {
             session = getSession(workspace, language);
             final Node node = NodeAccessor.BY_PATH.getNode(idOrPath, session);
 
-            if (excludedNodeTypes.contains(node.getPrimaryNodeType().getName()) || !SpringBeansAccess.getInstance().hasPermission("jcrestapi.upload", node)) {
-                throw new PathNotFoundException(node.getPath());
-            }
+            checkNodeIsInScope(node, UPLOAD);
 
             // check that the node is a folder
             if (node.isNodeType(Constants.NT_FOLDER)) {

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -410,6 +410,75 @@ public class APITest extends JerseyTest {
         assertTrue("the target should still be there", rootHasChild("escapeVictim"));
     }
 
+
+    @Test
+    public void singleDeleteShouldBeRefusedOnAChildTheScopeDoesNotAllow() throws Exception {
+
+        // the scope allows the operation on the parent the request resolves to, and refuses it on the child
+        makeParentAndChild("scopedParentA", "scopedChildA");
+        denyTheDeleteOperationOnlyOn("/scopedParentA/scopedChildA");
+
+        given().when()
+                .delete(getURLByPath("scopedParentA/children/scopedChildA"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the child should still be there once the operation is refused",
+                hasGrandChild("scopedParentA", "scopedChildA"));
+
+        // the same request goes through once the scope allows the operation on the child too
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().when()
+                .delete(getURLByPath("scopedParentA/children/scopedChildA"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NO_CONTENT);
+        assertFalse("the child should be gone once the operation is allowed",
+                hasGrandChild("scopedParentA", "scopedChildA"));
+    }
+
+    @Test
+    public void batchDeleteShouldBeRefusedOnAChildTheScopeDoesNotAllow() throws Exception {
+
+        makeParentAndChild("scopedParentB", "scopedChildB");
+        denyTheDeleteOperationOnlyOn("/scopedParentB/scopedChildB");
+
+        given().body("[\"scopedChildB\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("scopedParentB/children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the child should still be there once the operation is refused",
+                hasGrandChild("scopedParentB", "scopedChildB"));
+
+        // the same request goes through once the scope allows the operation on the child too
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().body("[\"scopedChildB\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("scopedParentB/children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the child should be gone once the operation is allowed",
+                hasGrandChild("scopedParentB", "scopedChildB"));
+    }
+
+    private void makeParentAndChild(String parent, String child) throws RepositoryException {
+        session.refresh(false);
+        session.getRootNode().addNode(parent, "nt:unstructured").addNode(child, "nt:unstructured");
+        session.save();
+    }
+
+    private boolean hasGrandChild(String parent, String child) throws RepositoryException {
+        session.refresh(false);
+        return session.getRootNode().hasNode(parent) && session.getRootNode().getNode(parent).hasNode(child);
+    }
+
     /**
      * Installs a permission service that allows the delete operation everywhere but on one node path.
      */

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -54,6 +54,8 @@ import org.jahia.modules.jcrestapi.api.PreparedQuery;
 import org.jahia.modules.json.Names;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.securityfilter.PermissionService;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.jahia.settings.SettingsBean;
 import org.junit.*;
 
@@ -387,6 +389,42 @@ public class APITest extends JerseyTest {
                 .assertThat()
                 .statusCode(SC_SEE_OTHER);
         assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
+    }
+
+
+    @Test
+    public void batchDeleteShouldNotEscapeTheResolvedNodeThroughARelativeSubElementName() throws Exception {
+
+        createNode("nt:address", "escapeSource");
+        createNode("nt:address", "escapeVictim");
+        denyTheDeleteOperationOnlyOn("/escapeVictim");
+
+        given().body("[\"../escapeVictim\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("escapeSource/children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the target should still be there", rootHasChild("escapeVictim"));
+    }
+
+    /**
+     * Installs a permission service that allows the delete operation everywhere but on one node path.
+     */
+    private void denyTheDeleteOperationOnlyOn(final String deniedPath) throws RepositoryException {
+
+        final PermissionService permissionService = mock(PermissionService.class);
+        when(permissionService.hasPermission(anyString(), any(Node.class))).thenAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                final String api = (String) invocation.getArguments()[0];
+                final Node node = (Node) invocation.getArguments()[1];
+                return !(("jcrestapi." + API.DELETE).equals(api) && deniedPath.equals(node.getPath()));
+            }
+        });
+        SpringBeansAccess.getInstance().setPermissionService(permissionService);
     }
 
     /**

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -334,6 +334,7 @@ public class APITest extends JerseyTest {
 
         given().body("[\"" + name + "\"]")
                 .contentType(ContentType.JSON)
+                .redirects().follow(false)
                 .when()
                 .delete(getURLByPath("children/"))
                 .then()
@@ -345,8 +346,12 @@ public class APITest extends JerseyTest {
         SpringBeansAccess.getInstance().setPermissionService(null);
         given().body("[\"" + name + "\"]")
                 .contentType(ContentType.JSON)
+                .redirects().follow(false)
                 .when()
-                .delete(getURLByPath("children/"));
+                .delete(getURLByPath("children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
         assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
     }
 
@@ -359,8 +364,11 @@ public class APITest extends JerseyTest {
 
         denyOnlyTheDeleteOperation();
 
+        // the refusal is read without following the redirect: the node's own URL answers 404 once the node is gone, so
+        // a followed redirect would report the refused status on a request that in fact deleted the node
         given().body("[\"" + name + "\"]")
                 .contentType(ContentType.JSON)
+                .redirects().follow(false)
                 .when()
                 .delete(generateURL(getURIById(id)))
                 .then()
@@ -372,8 +380,12 @@ public class APITest extends JerseyTest {
         SpringBeansAccess.getInstance().setPermissionService(null);
         given().body("[\"" + name + "\"]")
                 .contentType(ContentType.JSON)
+                .redirects().follow(false)
                 .when()
-                .delete(generateURL(getURIById(id)));
+                .delete(generateURL(getURIById(id)))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
         assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
     }
 

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -392,8 +392,13 @@ public class APITest extends JerseyTest {
     }
 
 
+    /**
+     * A name reaches {@code Node.getNode(String)}, which resolves a relative path, so a name can reach a node
+     * that is not below the one the request targets. What holds is that the scope is checked on the node the
+     * request removes. Case contributed by baptistegrimaud in review.
+     */
     @Test
-    public void batchDeleteShouldNotEscapeTheResolvedNodeThroughARelativeSubElementName() throws Exception {
+    public void batchDeleteShouldCheckTheScopeOfANodeNamedThroughARelativePath() throws Exception {
 
         createNode("nt:address", "escapeSource");
         createNode("nt:address", "escapeVictim");
@@ -407,9 +412,57 @@ public class APITest extends JerseyTest {
                 .then()
                 .assertThat()
                 .statusCode(SC_NOT_FOUND);
-        assertTrue("the target should still be there", rootHasChild("escapeVictim"));
+        assertTrue("the target should still be there once its own scope refuses the operation",
+                rootHasChild("escapeVictim"));
+
+        // the same request goes through once the scope allows the operation on the target itself
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().body("[\"../escapeVictim\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("escapeSource/children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the target should be gone once its own scope allows the operation",
+                rootHasChild("escapeVictim"));
     }
 
+    /**
+     * Removing a deeper node in one request is what a name carrying a path is for, so it keeps working and the
+     * scope is checked on that deeper node.
+     */
+    @Test
+    public void batchDeleteShouldRemoveADeeperNodeNamedThroughAPath() throws Exception {
+
+        makeParentAndChild("deepParent", "deepChild");
+        denyTheDeleteOperationOnlyOn("/deepParent/deepChild");
+
+        given().body("[\"deepParent/deepChild\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the deeper node should still be there once its own scope refuses the operation",
+                hasGrandChild("deepParent", "deepChild"));
+
+        // the same request goes through once the scope allows the operation on that node
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().body("[\"deepParent/deepChild\"]")
+                .contentType(ContentType.JSON)
+                .redirects().follow(false)
+                .when()
+                .delete(getURLByPath("children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the deeper node should be gone once its own scope allows the operation",
+                hasGrandChild("deepParent", "deepChild"));
+    }
 
     @Test
     public void singleDeleteShouldBeRefusedOnAChildTheScopeDoesNotAllow() throws Exception {

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -53,6 +53,7 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.jahia.modules.jcrestapi.api.PreparedQuery;
 import org.jahia.modules.json.Names;
 import org.jahia.services.content.JCRContentUtils;
+import org.jahia.services.securityfilter.PermissionService;
 import org.jahia.settings.SettingsBean;
 import org.junit.*;
 
@@ -74,6 +75,13 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.*;
 import static org.hamcrest.Matchers.*;
 import static org.jahia.modules.jcrestapi.APIApplication.SYS_PROP_DEPRECATION_FILTER_DISABLED;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Christophe Laprun
@@ -151,6 +159,7 @@ public class APITest extends JerseyTest {
 
     @After
     public void afterEach() {
+        SpringBeansAccess.getInstance().setPermissionService(null);
         session.logout();
     }
 
@@ -290,6 +299,105 @@ public class APITest extends JerseyTest {
                 .get(urlByPath);
     }
 
+    @Test
+    public void deleteShouldBeRefusedOnANodeTheScopeDoesNotAllow() throws Exception {
+
+        final String name = "singleScoped";
+        createNode("nt:address", name);
+
+        denyOnlyTheDeleteOperation();
+
+        given().when()
+                .delete(getURLByPath("children/" + name))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still be there once the operation is refused", rootHasChild(name));
+
+        // the same request goes through once the scope allows the operation again
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().when()
+                .delete(getURLByPath("children/" + name))
+                .then()
+                .assertThat()
+                .statusCode(SC_NO_CONTENT);
+        assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
+    }
+
+    @Test
+    public void batchDeleteShouldBeRefusedOnANodeTheScopeDoesNotAllow() throws Exception {
+
+        final String name = "batchScoped";
+        createNode("nt:address", name);
+
+        denyOnlyTheDeleteOperation();
+
+        given().body("[\"" + name + "\"]")
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(getURLByPath("children/"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still be there once the operation is refused", rootHasChild(name));
+
+        // the same request goes through once the scope allows the operation again
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().body("[\"" + name + "\"]")
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(getURLByPath("children/"));
+        assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
+    }
+
+    @Test
+    public void batchDeleteOfTheNodeItselfShouldBeRefusedOnANodeTheScopeDoesNotAllow() throws Exception {
+
+        // a batch payload sent on the node itself, i.e. with no sub-element type, deletes that very node
+        final String name = "batchScopedItself";
+        final String id = createNode("nt:address", name);
+
+        denyOnlyTheDeleteOperation();
+
+        given().body("[\"" + name + "\"]")
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(generateURL(getURIById(id)))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still be there once the operation is refused", rootHasChild(name));
+
+        // the same request goes through once the scope allows the operation again
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().body("[\"" + name + "\"]")
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(generateURL(getURIById(id)));
+        assertFalse("the node should be gone once the operation is allowed", rootHasChild(name));
+    }
+
+    /**
+     * Installs a permission service that allows every operation but the delete one, so that a refused delete cannot be
+     * confused with a node the test can no longer read.
+     */
+    private void denyOnlyTheDeleteOperation() throws RepositoryException {
+
+        final PermissionService permissionService = mock(PermissionService.class);
+        when(permissionService.hasPermission(anyString(), any(Node.class))).thenReturn(true);
+        when(permissionService.hasPermission(eq("jcrestapi." + API.DELETE), any(Node.class))).thenReturn(false);
+        SpringBeansAccess.getInstance().setPermissionService(permissionService);
+    }
+
+    /**
+     * Reads the repository back through the test's own session rather than through the API, so that the result does not
+     * depend on what the API is allowed to return.
+     */
+    private boolean rootHasChild(String name) throws RepositoryException {
+        session.refresh(false);
+        return session.getRootNode().hasNode(name);
+    }
+
     private Object[] createChildrenAssertions(String nodeType, String urlByPath, String... childNames) {
         if (childNames != null) {
             final Object[] result = new Object[childNames.length * 8];
@@ -309,8 +417,8 @@ public class APITest extends JerseyTest {
         return null;
     }
 
-    private void createNode(String nodeType, String name) {
-        given().body("{\"type\": \"" + nodeType + "\"}")
+    private String createNode(String nodeType, String name) {
+        return given().body("{\"type\": \"" + nodeType + "\"}")
                 .contentType(ContentType.JSON)
                 .when()
                 .post(getURLByPath("children/" + name))
@@ -321,7 +429,7 @@ public class APITest extends JerseyTest {
                         "name", equalTo(name),
                         "type", equalTo(nodeType),
                         "id", notNullValue()
-                );
+                ).extract().path("id");
     }
 
     @Test


### PR DESCRIPTION
## Summary

The API serves a node only when the node's primary type is one it exposes, and when the caller's scope allows the operation on it. A deletion is answered against the node it removes. That is the node named by the request path when the request removes that node, and the child when the request removes a child. Both shapes of the delete route, one child at a time and several at once, apply the same rule to the same node.

## Change

- `API.checkNodeIsInScope(Node, String)` carries the check the API applies to a node. The node's primary type must be absent from `excludedNodeTypes`, and `hasPermission("jcrestapi." + operation, node)` must allow the operation. The method throws `PathNotFoundException` otherwise.
- `perform()` and `performBatchDelete()` both call it on the node the request resolved to. That covers the two entry points a batch deletion reaches, `Nodes` by id and `Paths` by path, and every sub-element type the route accepts, including the empty one that removes the resolved node itself.
- `API.checkChildIsInScope(Node, String)` applies the same check to the child a children deletion removes. `ChildrenElementAccessor.delete` removes `node.getNode(subElement)`, so the child is the node that leaves the repository, and the resolved node says nothing about it. Both shapes of the route call it. It is scoped to a deletion: reading or writing a sub-element is a wider question than the node being removed, and a children listing already filters on `jcrestapi.child` through `NODE_FILTER`.
- The upload route calls `checkNodeIsInScope` rather than repeating the condition inline, so the rule has one home.

## Verification

`APITest` drives the real routes against the test repository, with a permission service that refuses one operation, or refuses it on one path.

- A single delete, a batch delete of children, and a batch delete sent on the node itself each answer `404` when the scope refuses the operation on the node the request resolved to.
- A single delete and a batch delete each answer `404` when the scope allows the operation on the resolved node and refuses it on the child. The child is still in the repository afterwards. Removing either call site turns exactly its own case red, so neither passes on the other's guard.
- A name that carries a path, whether it points below the target like `folder/child` or outside it like `../sibling`, is answered by the scope of the node it reaches. The check resolves through the same call the accessor removes through, so the node checked is the node removed.
- Every refusal above is paired with the same request going through once the scope allows the operation, so each assertion is checked in both directions.
- The read-back goes through the test's own session rather than the API. Its result therefore does not depend on what the API is allowed to return.

The suite is green at 53 tests, `APITest` at 17. Removing the batch call site turns all three batch cases red, and the single-route case stays green.

## Compatibility

One request that used to succeed now answers `404`: removing a child the API does not expose. That affects the single-element route as well, which is why the title changed. The rule is about the node a deletion removes rather than about batch deletions.

A name that carries a path keeps working. Removing a deeper node in one request is what such a name is for, and it now answers to that node's own scope rather than to the scope of the node the request path names.
