### PR TITLE
fix: apply the node scope check to the rename route

### DIFF
--- a/.chachalog/VEB5N9.md
+++ b/.chachalog/VEB5N9.md
@@ -5,3 +5,5 @@ jcrestapi: patch
 Restricted renaming in the JCR REST API to the nodes it is configured to expose.
 
 A rename is now answered against the node it renames, the way every other operation of this API already is. A request is refused when the API does not expose that node. Grant the move permission for the JCR REST API on that node, or remove the node's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`. The rename operation is named `move`. A site that grants the whole `jcrestapi` API needs no change, and that is what the authorization configuration Jahia ships does. A site whose authorization configuration lists the operations of this API one by one must add `jcrestapi.move` to keep the rename endpoint working.
+
+A rename that moves the node under a different parent is answered against that parent as well. The new name is resolved as a relative path, so a name such as `../folder/name` moves the node rather than renaming it in place. Such a request is refused when the API does not expose the parent the node lands under.

--- a/.chachalog/VEB5N9.md
+++ b/.chachalog/VEB5N9.md
@@ -1,0 +1,7 @@
+---
+jcrestapi: patch
+---
+
+Restricted renaming in the JCR REST API to the nodes it is configured to expose.
+
+A rename is now answered against the node it renames, the way every other operation of this API already is. A request is refused when the API does not expose that node. Grant the move permission for the JCR REST API on that node, or remove the node's type from `jahia.find.nodeTypesToSkip` in `jahia.properties`. The rename operation is named `move`. A site that grants the whole `jcrestapi` API needs no change, and that is what the authorization configuration Jahia ships does. A site whose authorization configuration lists the operations of this API one by one must add `jcrestapi.move` to keep the rename endpoint working.

--- a/src/main/java/org/jahia/modules/jcrestapi/API.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/API.java
@@ -85,6 +85,7 @@ public class API {
     public static final String CREATE_OR_UPDATE = "createOrUpdate";
     public static final String READ = "read";
     public static final String UPLOAD = "upload";
+    public static final String MOVE = "move";
     public static final String AS_JSON_STRING = "asJSONString";
 
     static final String API_PATH = "/api/jcr/v1";

--- a/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
@@ -49,7 +49,9 @@ import org.jahia.modules.json.JSONNode;
 import org.jahia.modules.json.JSONProperty;
 
 import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -174,8 +176,8 @@ public class Nodes extends API {
      * Renames the node the request resolves to, and answers it the way the rest of the API answers a node: the node's
      * primary type must be one the API exposes, and the caller's scope must allow the move on it.
      *
-     * <p>The new name is a name rather than a path, so the node keeps its parent and the rename reaches no node other
-     * than the one named by the request path. That is why the resolved node is the only one checked here.
+     * <p>The new name resolves as a relative path, so a name such as {@code ../sibling/name} lands the node under
+     * another parent. A rename that changes the node's parent therefore answers for that parent too.
      *
      * @param id      the identifier of the node to rename
      * @param newName the name the node takes
@@ -192,6 +194,7 @@ public class Nodes extends API {
             session = getSession(workspace, language);
             final Node node = session.getNodeByIdentifier(id);
             checkNodeIsInScope(node, MOVE);
+            checkDestinationIsInScope(node, newName);
             session.move(node.getPath(), node.getParent().getPath() + "/" + newName);
             session.save();
             return ElementAccessor.getSeeOtherResponse(URIUtils.getIdURI(id), context);
@@ -199,6 +202,34 @@ public class Nodes extends API {
             throw new APIException(e);
         } finally {
             closeSession(session);
+        }
+    }
+
+    /**
+     * Checks that the node a rename lands the node under is exposed by the API, when that is not the node's own
+     * parent.
+     *
+     * <p>The new name resolves the way a JCR path resolves, as a <em>relative path</em> rather than a name, so
+     * {@code ../sibling/name} lands the node under another parent and {@code .} lands it beside its own parent. The
+     * destination is therefore resolved here through the same path {@link Session#move} builds, with {@code /..}
+     * appended so that JCR answers with the node that gains the child. The node checked is the node the move
+     * reaches, whatever shape the name takes, and containment is deliberately not enforced: moving a node under
+     * another parent is what such a name is for.
+     *
+     * <p>A name that keeps the node under its own parent reaches no node the request has not already answered for,
+     * so it is left alone. A name that resolves to no node, or to no node at all above the root, is left to JCR,
+     * which reports it the same way as before.
+     *
+     * @param node    the node the request resolved to
+     * @param newName the name the node takes, resolved relative to that node's parent
+     * @throws PathNotFoundException if the node the rename lands the node under is not exposed by the API
+     * @throws RepositoryException   if that node cannot be read
+     */
+    private void checkDestinationIsInScope(Node node, String newName) throws RepositoryException {
+        final Node sourceParent = node.getParent();
+        final Node destinationParent = node.getSession().getNode(sourceParent.getPath() + "/" + newName + "/..");
+        if (!destinationParent.isSame(sourceParent)) {
+            checkNodeIsInScope(destinationParent, MOVE);
         }
     }
 }

--- a/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
@@ -170,6 +170,18 @@ public class Nodes extends API {
         return perform(workspace, language, id, subElementType, subElement, context, DELETE, null);
     }
 
+    /**
+     * Renames the node the request resolves to, and answers it the way the rest of the API answers a node: the node's
+     * primary type must be one the API exposes, and the caller's scope must allow the move on it.
+     *
+     * <p>The new name is a name rather than a path, so the node keeps its parent and the rename reaches no node other
+     * than the one named by the request path. That is why the resolved node is the only one checked here.
+     *
+     * @param id      the identifier of the node to rename
+     * @param newName the name the node takes
+     * @param context a UriInfo instance, automatically injected, providing context about the request URI
+     * @return a Response ready to be sent to the client
+     */
     @POST
     @Path("/{id}/moveto/{newName}")
     public Object renameNode(@PathParam("id") String id,
@@ -179,6 +191,7 @@ public class Nodes extends API {
         try {
             session = getSession(workspace, language);
             final Node node = session.getNodeByIdentifier(id);
+            checkNodeIsInScope(node, MOVE);
             session.move(node.getPath(), node.getParent().getPath() + "/" + newName);
             session.save();
             return ElementAccessor.getSeeOtherResponse(URIUtils.getIdURI(id), context);

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -521,6 +521,70 @@ public class APITest extends JerseyTest {
                 hasGrandChild("scopedParentB", "scopedChildB"));
     }
 
+    @Test
+    public void renameShouldBeRefusedOnANodeTheScopeDoesNotAllow() throws Exception {
+
+        final String parent = "renameScopedParent";
+        final String name = "renameScoped";
+        final String newName = "renameScopedDone";
+        final String id = createChildNode(parent, name);
+
+        denyOnlyTheMoveOperation();
+
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/" + newName))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still carry its name once the operation is refused", hasGrandChild(parent, name));
+        assertFalse("the node should not carry its new name once the operation is refused", hasGrandChild(parent, newName));
+
+        // the same request goes through once the scope allows the operation again
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/" + newName))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the node should have left its name once the operation is allowed", hasGrandChild(parent, name));
+        assertTrue("the node should carry its new name once the operation is allowed", hasGrandChild(parent, newName));
+    }
+
+    /**
+     * The scope is checked on the node the request resolves to, so a scope that refuses the move on one node leaves
+     * the same request on another node alone.
+     */
+    @Test
+    public void renameShouldBeRefusedOnTheNodeTheRequestResolvesTo() throws Exception {
+
+        final String parent = "renameResolvedParent";
+        final String refusedName = "renameRefused";
+        final String allowedName = "renameAllowed";
+        final String refusedId = createChildNode(parent, refusedName);
+        final String allowedId = createChildNode(parent, allowedName);
+
+        denyTheMoveOperationOnlyOn("/" + parent + "/" + refusedName);
+
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(refusedId) + "/moveto/renameRefusedDone"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the refused node should still carry its name", hasGrandChild(parent, refusedName));
+
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(allowedId) + "/moveto/renameAllowedDone"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the allowed node should have left its name", hasGrandChild(parent, allowedName));
+        assertTrue("the allowed node should carry its new name", hasGrandChild(parent, "renameAllowedDone"));
+    }
+
     private void makeParentAndChild(String parent, String child) throws RepositoryException {
         session.refresh(false);
         session.getRootNode().addNode(parent, "nt:unstructured").addNode(child, "nt:unstructured");
@@ -558,6 +622,50 @@ public class APITest extends JerseyTest {
         final PermissionService permissionService = mock(PermissionService.class);
         when(permissionService.hasPermission(anyString(), any(Node.class))).thenReturn(true);
         when(permissionService.hasPermission(eq("jcrestapi." + API.DELETE), any(Node.class))).thenReturn(false);
+        SpringBeansAccess.getInstance().setPermissionService(permissionService);
+    }
+
+    /**
+     * Creates a node under the given parent, creating that parent first, and returns the identifier of the child.
+     */
+    private String createChildNode(String parent, String name) {
+        createNode("nt:unstructured", parent);
+        return given().body("{\"type\": \"nt:unstructured\"}")
+                .contentType(ContentType.JSON)
+                .when()
+                .post(getURLByPath(parent + "/children/" + name))
+                .then()
+                .assertThat()
+                .body("name", equalTo(name), "id", notNullValue())
+                .extract().path("id");
+    }
+
+    /**
+     * Installs a permission service that allows every operation but the move one, so that a refused rename cannot be
+     * confused with a node the test can no longer read.
+     */
+    private void denyOnlyTheMoveOperation() throws RepositoryException {
+
+        final PermissionService permissionService = mock(PermissionService.class);
+        when(permissionService.hasPermission(anyString(), any(Node.class))).thenReturn(true);
+        when(permissionService.hasPermission(eq("jcrestapi." + API.MOVE), any(Node.class))).thenReturn(false);
+        SpringBeansAccess.getInstance().setPermissionService(permissionService);
+    }
+
+    /**
+     * Installs a permission service that allows the move operation everywhere but on one node path.
+     */
+    private void denyTheMoveOperationOnlyOn(final String deniedPath) throws RepositoryException {
+
+        final PermissionService permissionService = mock(PermissionService.class);
+        when(permissionService.hasPermission(anyString(), any(Node.class))).thenAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                final String api = (String) invocation.getArguments()[0];
+                final Node node = (Node) invocation.getArguments()[1];
+                return !(("jcrestapi." + API.MOVE).equals(api) && deniedPath.equals(node.getPath()));
+            }
+        });
         SpringBeansAccess.getInstance().setPermissionService(permissionService);
     }
 

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -585,6 +585,100 @@ public class APITest extends JerseyTest {
         assertTrue("the allowed node should carry its new name", hasGrandChild(parent, "renameAllowedDone"));
     }
 
+    /**
+     * The new name resolves as a relative path, so a name such as {@code ../sibling/name} lands the node under
+     * another parent. The rename is answered by that parent's own scope. Containment is not enforced, which is
+     * deliberate: moving a node under another parent is what such a name is for.
+     */
+    @Test
+    public void renameShouldCheckTheScopeOfTheParentTheNodeMovesUnder() throws Exception {
+
+        final String parent = "renameDestParent";
+        final String name = "renameDestChild";
+        final String other = "renameDestOther";
+        final String id = createChildNode(parent, name);
+        createNode("nt:unstructured", other);
+
+        denyTheMoveOperationOnlyOn("/" + other);
+
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/..%2F" + other + "%2Fmoved"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still carry its name once the destination refuses the operation",
+                hasGrandChild(parent, name));
+        assertFalse("the node should not have landed under the destination", hasGrandChild(other, "moved"));
+
+        // the same request goes through once the destination's own scope allows the operation
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/..%2F" + other + "%2Fmoved"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the node should have left its parent", hasGrandChild(parent, name));
+        assertTrue("the node should have landed under the destination", hasGrandChild(other, "moved"));
+    }
+
+    /**
+     * A name may reach a parent deeper in the tree, and that deeper node is the one the scope answers for.
+     */
+    @Test
+    public void renameShouldMoveANodeUnderADeeperParentNamedThroughAPath() throws Exception {
+
+        final String parent = "renameDeepParent";
+        final String name = "renameDeepChild";
+        final String id = createChildNode(parent, name);
+        createChildNode("renameDeepOther", "deep");
+
+        denyTheMoveOperationOnlyOn("/renameDeepOther/deep");
+
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/..%2FrenameDeepOther%2Fdeep%2Fmoved"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still carry its name", hasGrandChild(parent, name));
+
+        SpringBeansAccess.getInstance().setPermissionService(null);
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/..%2FrenameDeepOther%2Fdeep%2Fmoved"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        session.refresh(false);
+        assertTrue("the node should have landed under the deeper parent",
+                session.getRootNode().getNode("renameDeepOther").getNode("deep").hasNode("moved"));
+    }
+
+    /**
+     * A name of {@code .} carries no separator and still lands the node beside its own parent, so the node it
+     * lands under is the one above. The scope answers for that node too.
+     */
+    @Test
+    public void renameShouldCheckTheScopeWhenANameLandsTheNodeBesideItsOwnParent() throws Exception {
+
+        final String parent = "renameDotParent";
+        final String name = "renameDotChild";
+        final String id = createChildNode(parent, name);
+
+        denyTheMoveOperationOnlyOn("/");
+
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/."))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertTrue("the node should still carry its name once the root refuses the operation",
+                hasGrandChild(parent, name));
+    }
+
     private void makeParentAndChild(String parent, String child) throws RepositoryException {
         session.refresh(false);
         session.getRootNode().addNode(parent, "nt:unstructured").addNode(child, "nt:unstructured");

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -679,6 +679,40 @@ public class APITest extends JerseyTest {
                 hasGrandChild(parent, name));
     }
 
+    /**
+     * A rename that keeps the node under its own parent reaches no node the request has not already answered for, so
+     * the parent's own scope is not asked. Were it asked, a scope that covers a node without covering its container
+     * would stop renaming that node, and the shipped {@code access_category} scope has exactly that shape.
+     */
+    @Test
+    public void renameShouldNotAnswerForTheParentWhenTheNodeKeepsIt() throws Exception {
+
+        final String parent = "renameKeepParent";
+        final String name = "renameKeepChild";
+        final String id = createChildNode(parent, name);
+        final String outsideId = createChildNode("renameKeepOther", "renameKeepOutsider");
+
+        denyTheMoveOperationOnlyOn("/" + parent);
+
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/renameKeepDone"))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertTrue("a plain rename should go through while only the parent's scope refuses the operation",
+                hasGrandChild(parent, "renameKeepDone"));
+
+        // the same scope does refuse a rename that lands a node under that parent, so the arm above is not vacuous
+        given().redirects().follow(false).urlEncodingEnabled(false)
+                .when()
+                .post(generateURL(getURIById(outsideId) + "/moveto/..%2F" + parent + "%2Fmoved"))
+                .then()
+                .assertThat()
+                .statusCode(SC_NOT_FOUND);
+        assertFalse("a rename landing a node under that parent should be refused", hasGrandChild(parent, "moved"));
+    }
+
     private void makeParentAndChild(String parent, String child) throws RepositoryException {
         session.refresh(false);
         session.getRootNode().addNode(parent, "nt:unstructured").addNode(child, "nt:unstructured");


### PR DESCRIPTION
## Summary

The JCR REST API exposes a node only when the node's primary type is one the API serves. The caller's scope must also allow the operation on that node. Every route of this API applies both rules to the node the route answers. The rename route applied neither rule, so a rename reached nodes the rest of the API refuses. The rename route now applies the same rules to the node it renames.

## Change

- `API.MOVE` names the rename operation, so the rule reads `hasPermission("jcrestapi.move", node)`. The upload route already carries its own operation name in the same way.
- `Nodes.renameNode` calls `API.checkNodeIsInScope(Node, String)` on the node the request resolves to, before the move. That method is the one `perform()`, `performBatchDelete()` and the upload route already call, so the rule keeps one home.
- `Nodes.checkDestinationIsInScope(Node, String)` answers for the node a rename lands the node under, when that is not the node's own parent. The new name resolves as a relative path, so `../folder/name` lands the node under another parent and `.` lands it beside its own parent. The destination is resolved through the same path `Session.move` builds. The node checked is therefore the node that gains the child, whatever shape the name takes. A name that keeps the node under its own parent reaches no node the request has not already answered for, so it is left alone.

## Verification

`APITest` drives the real route against the test repository, with a permission service that refuses the move operation, or refuses it on one path.

- A rename answers `404` when the scope refuses the move on the node the request resolves to, and the node still carries its name afterwards.
- A rename answers `404` on the node whose path the scope refuses, while the same request on another node answers `303` and renames that node. The rule therefore reads the node the request resolved to, rather than refusing every rename.
- Every refusal above is paired with the same request going through once the scope allows the move, so each assertion is checked in both directions.
- The permission service used in the refusing arm allows every other operation. A refused rename can therefore not be confused with a node the test can no longer read.
- The read-back goes through the test's own session rather than the API. Its result therefore does not depend on what the API is allowed to return.

Three further cases cover the node a rename lands under. A name reaching another parent answers `404` while that parent's scope refuses the move. It answers `303` once that scope allows, and the node sits under the destination afterwards. A name reaching a deeper parent is answered by that deeper node. A name of `.` is answered by the node above, which is where it lands the node.

The suite is green at 58 tests, `APITest` at 22. Removing either new call site turns exactly its own cases red and leaves the rest green.

The module was also built and deployed onto a running Jahia 8.2.4.0-SNAPSHOT, and the route driven there:

- A rename answers `404` when the caller's scope does not grant this API, and a read-back through GraphQL shows the node still carrying its name.
- The same rename answers `303` when the caller's scope grants this API, and the read-back shows the node carrying its new name.

Run the same two requests against the base branch for the contrast. The bundle reaches `ACTIVE` on deploy, and the instance logs carry no error from the change.

## Compatibility

One request that used to succeed now answers `404`: renaming a node this API does not expose.

`move` is a new operation name for this API. A configuration that grants the whole `jcrestapi` API covers it, and that is what the authorization configuration Jahia ships does. A configuration that lists the operations of this API one by one must add `jcrestapi.move` to keep the rename route working.

A rename that moves the node under a different parent is answered against that parent as well. Such a request is refused when the API does not expose the parent the node lands under. Moving a node under another parent stays available, and is answered by that parent's own scope. That follows the reasoning of the per-child check on the delete routes.
