### PR TITLE
fix: rename a node whose parent is the repository root

### DIFF
--- a/.chachalog/rnMv7Qx2.md
+++ b/.chachalog/rnMv7Qx2.md
@@ -1,0 +1,7 @@
+---
+jcrestapi: patch
+---
+
+Fixed the rename route of the JCR REST API for a node whose parent is the repository root.
+
+`POST /modules/api/jcr/v1/{workspace}/{language}/nodes/{id}/moveto/{newName}` answered 500 for such a node, because a path it built carried an empty segment. The route now renames the node and answers 303, the way it already does for a node deeper in the tree.

--- a/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
+++ b/src/main/java/org/jahia/modules/jcrestapi/Nodes.java
@@ -195,7 +195,7 @@ public class Nodes extends API {
             final Node node = session.getNodeByIdentifier(id);
             checkNodeIsInScope(node, MOVE);
             checkDestinationIsInScope(node, newName);
-            session.move(node.getPath(), node.getParent().getPath() + "/" + newName);
+            session.move(node.getPath(), getDestinationPath(node, newName));
             session.save();
             return ElementAccessor.getSeeOtherResponse(URIUtils.getIdURI(id), context);
         } catch (Exception e) {
@@ -227,9 +227,24 @@ public class Nodes extends API {
      */
     private void checkDestinationIsInScope(Node node, String newName) throws RepositoryException {
         final Node sourceParent = node.getParent();
-        final Node destinationParent = node.getSession().getNode(sourceParent.getPath() + "/" + newName + "/..");
+        final Node destinationParent = node.getSession().getNode(getDestinationPath(node, newName) + "/..");
         if (!destinationParent.isSame(sourceParent)) {
             checkNodeIsInScope(destinationParent, MOVE);
         }
+    }
+
+    /**
+     * Builds the path a rename moves the node to. The new name resolves relative to the node's parent, so it is joined
+     * to that parent's path. The root node's path is the separator on its own, so joining a name to it directly leaves
+     * an empty segment in the path, and JCR refuses such a path.
+     *
+     * @param node    the node the request resolved to
+     * @param newName the name the node takes, resolved relative to that node's parent
+     * @return the absolute path the node moves to
+     * @throws RepositoryException if the node's parent cannot be read
+     */
+    private static String getDestinationPath(Node node, String newName) throws RepositoryException {
+        final String parentPath = node.getParent().getPath();
+        return ("/".equals(parentPath) ? "" : parentPath) + "/" + newName;
     }
 }

--- a/src/test/java/org/jahia/modules/jcrestapi/APITest.java
+++ b/src/test/java/org/jahia/modules/jcrestapi/APITest.java
@@ -713,6 +713,46 @@ public class APITest extends JerseyTest {
         assertFalse("a rename landing a node under that parent should be refused", hasGrandChild(parent, "moved"));
     }
 
+    /**
+     * The root node's path is the separator on its own, so joining a name to it must not leave an empty segment in
+     * the path the rename moves the node to. A node whose parent is the root renames the way a deeper node does.
+     */
+    @Test
+    public void renameShouldMoveANodeWhoseParentIsTheRoot() throws Exception {
+
+        final String name = "renameAtRoot";
+        final String newName = "renameAtRootDone";
+        final String id = createNode("nt:unstructured", name);
+
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/" + newName))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the node should have left its name", rootHasChild(name));
+        assertTrue("the node should carry its new name", rootHasChild(newName));
+    }
+
+    @Test
+    public void renameShouldMoveANodeWhoseParentIsNotTheRoot() throws Exception {
+
+        final String parent = "renameDeeperParent";
+        final String name = "renameDeeper";
+        final String newName = "renameDeeperDone";
+        makeParentAndChild(parent, name);
+        final String id = session.getRootNode().getNode(parent).getNode(name).getIdentifier();
+
+        given().redirects().follow(false)
+                .when()
+                .post(generateURL(getURIById(id) + "/moveto/" + newName))
+                .then()
+                .assertThat()
+                .statusCode(SC_SEE_OTHER);
+        assertFalse("the node should have left its name", hasGrandChild(parent, name));
+        assertTrue("the node should carry its new name", hasGrandChild(parent, newName));
+    }
+
     private void makeParentAndChild(String parent, String child) throws RepositoryException {
         session.refresh(false);
         session.getRootNode().addNode(parent, "nt:unstructured").addNode(child, "nt:unstructured");


### PR DESCRIPTION
Closes [jcrestapi#91](https://github.com/Jahia/jcrestapi/issues/91).

## Summary

`POST /modules/api/jcr/v1/{workspace}/{language}/nodes/{id}/moveto/{newName}` answered 500 when the node's parent was the repository root. The route built the path the move targets by joining the parent's path and the new name. The root node's path is the separator on its own, so that join produced a path carrying an empty segment. `Session.move` refused such a path and reported `Path is invalid: //<newName>`. A node one level deeper renamed correctly, so the route worked everywhere except directly under the root.

## Change

`Nodes.getDestinationPath(Node, String)` builds the path the rename moves the node to. It drops the parent path when the parent is the root, so the destination reads `/<newName>`. Both places that need this path now call it, so the path is built in one place.

- `renameNode` passes it to `Session.move`, rather than joining the two strings itself.
- `checkDestinationIsInScope` resolves the destination's parent through it, rather than repeating the same join. That method arrived with [jcrestapi#90](https://github.com/Jahia/jcrestapi/pull/90), which merged before this branch rebased.

The new name keeps resolving relative to the node's parent, so a name carrying a path segment reaches the same node as before.

## Verification

`APITest` drives the real route against the test repository.

- A node whose parent is the root answers 303. A read-back through the test's own session shows the node carrying its new name, and no longer carrying the old one.
- A node one level deeper answers 303 the same way. That case passes on the base branch too, so it records the behaviour the change leaves alone.

The first test fails on the base branch with 500, and passes with the change.

Both call sites had to change, and that was measured rather than assumed. The rebase onto [jcrestapi#90](https://github.com/Jahia/jcrestapi/pull/90) was first resolved with only the `Session.move` join routed through the new method. `renameShouldMoveANodeWhoseParentIsTheRoot` then failed with 500, because `checkDestinationIsInScope` still built the join itself. Routing that method through `getDestinationPath` turned the test green.

The suite is green at 85 tests, `APITest` at 25. `mvn verify -DskipTests` builds the bundle.

## Compatibility

A request that answered 500 now answers 303 and renames the node. No request that already worked changes.
